### PR TITLE
Last ESR set to 128

### DIFF
--- a/data.yaml
+++ b/data.yaml
@@ -209,12 +209,6 @@ r_name: HTML Source Editor
 r_link: https://addons.thunderbird.net/addon/html-source-editor/
 r_id: edithtmlsource@jobisoft.de
 ---
-u_name: ThunderStats! Your Thunderbird Statistics!
-u_id: thunderstats@micz.it
-r_name: ThirdStats
-r_link: https://addons.thunderbird.net/addon/thirdstats/
-r_id: thirdstats@devmount.de
----
 u_name: Toggle Quotes
 u_id: quotes@dillinger
 r_name: Quote Colors & Collapse

--- a/script.js
+++ b/script.js
@@ -9,7 +9,7 @@
 // const R_LINK_FIELD = "r_link"; //.gsx$url.$t
 
 // Assume current ESR as current version, if it could not be extracted from user agent.
-var gUsedVersion = 91;
+var gUsedVersion = 128;
 
 // Define how old the latest version of an add-on may be, before it is considered unmaintained.
 const maintainedSpan = 365*24*60*60*1000; // Year


### PR DESCRIPTION
If an addon is not found, the search on addons.thunderbird.net filters on version 91.
With this patch it filters on version 128.

Maybe it could be changed to fetch live the last ESR from the thunderbird repo (or something similar).

